### PR TITLE
Add more helpful env template

### DIFF
--- a/env-template
+++ b/env-template
@@ -4,10 +4,9 @@
 # Jupyter server starts at port 8888
 # JUPYTER_PORT=5000
 
-# Uncomment the following and set your own JUPYTER_PASSWORD. You can set the value to blank (as shown below) to remove password all together
-# JUPYTER_PASSWORD=
+# Uncomment the following and set your own JUPYTER_PASSWORD. By default, the password is set to walkerlab.
+# JUPYTER_PASSWORD='my custom password'
 
-# The following sets the project name such that by default
-# docker compose project name would include the user's login name
-# to decrease the chance of name collision
-COMPOSE_PROJECT_NAME=${LOGNAME}_project
+# Uncomment and set the following to something unique in case you encounter docker compose name collision
+# COMPOSE_PROJECT_NAME=unique_project_name
+


### PR DESCRIPTION
Updated env template to reflect the fact blank password is not allowed. Also COMPOSE_PROJECT_NAME is now set to be optional.